### PR TITLE
feat: special handling for auth_aws_iam

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,5 @@ exclude = '''
   | buck-out
   | build
   | dist
+)/
+'''

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,12 +7,14 @@ twine==1.13.0
 
 cmarkgfm==0.4.2
 m2r==0.2.1
+pyaml~=20.4.0
 recommonmark==0.5.0
 Sphinx==2.0.0
 sphinx-rtd-theme==0.4.3
 watchdog==0.9.0
 
 coverage==4.5.3
+hypothesis~=5.43.3
 pylint==2.3.1
 pytest==4.4.0
 pytest-cov==2.6.1

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("README.md") as readme_file:
 with open("CHANGELOG.md") as changelog_file:
     changelog = changelog_file.read()
 
-requirements = ["anyconfig==0.9.9", "hvac==0.7.2"]
+requirements = ["anyconfig==0.9.9", "hvac==0.7.2", "boto3~=1.14.0"]
 
 setup_requirements = ["pytest-runner"]
 

--- a/tests/unit/test_vault_auth.py
+++ b/tests/unit/test_vault_auth.py
@@ -3,7 +3,6 @@ Tests for the auth convenience method
 """
 
 from unittest.mock import patch, mock_open, call, Mock
-from copy import deepcopy
 from json import dumps as jdumps
 from stat import S_IRUSR, S_IWUSR
 
@@ -65,39 +64,38 @@ def test_auto_auth_bad_method(mock_load, mock_is_authenticated, localhost_client
     mock_load.assert_called_with("config.json", ac_parser="test_parser")
 
 
+AWS_IAM_VAULT_CREDS = [
+    {"access_key": "test_access_key", "secret_key": "test_secret_key", "session_token": "test_session_token"},
+    {"access_key": "test_access_key", "secret_key": "test_secret_key"},
+]
+
+
+@pytest.mark.parametrize("vault_creds", AWS_IAM_VAULT_CREDS)
 @patch("vault_anyconfig.vault_anyconfig.Client.auth_aws_iam")
 @patch("vault_anyconfig.vault_anyconfig.Client.is_authenticated")
 @patch("vault_anyconfig.vault_anyconfig.loads_base")
-def test_auto_auth_aws_iam_method(mock_load, mock_is_authenticated, mock_auth_kubernetes, localhost_client):
+def test_auto_auth_aws_iam_method(mock_load, mock_is_authenticated, mock_auth_aws_iam, vault_creds, localhost_client):
     """
     Test that the aws_iam method *with* hardcoded aws creds is called directly
     """
-    local_vault_creds = {
-        "vault_creds": {
-            "auth_method": "aws_iam",
-            "role": "test_role",
-            "access_key": "test_access_key",
-            "secret_key": "test_secret_key",
-            "session_token": "test_session_token",
-        }
-    }
+    local_vault_creds = {"vault_creds": {"auth_method": "aws_iam", "role": "test_role"}}
+    local_vault_creds["vault_creds"].update(vault_creds)
 
     mock_load.return_value = local_vault_creds
     mock_is_authenticated.return_value = False
 
     localhost_client.auto_auth("config.json", ac_parser="test_parser")
     mock_load.assert_called_with("config.json", ac_parser="test_parser")
-    mock_auth_kubernetes.assert_called_with(
-        access_key="test_access_key", secret_key="test_secret_key", session_token="test_session_token", role="test_role"
-    )
+    mock_auth_aws_iam.assert_called_with(**vault_creds, role="test_role")
 
 
+@pytest.mark.parametrize("vault_creds", AWS_IAM_VAULT_CREDS)
 @patch("boto3.Session.get_credentials")
 @patch("vault_anyconfig.vault_anyconfig.Client.auth_aws_iam")
 @patch("vault_anyconfig.vault_anyconfig.Client.is_authenticated")
 @patch("vault_anyconfig.vault_anyconfig.loads_base")
 def test_auto_auth_aws_iam_method_role_only(
-    mock_load, mock_is_authenticated, mock_auth_kubernetes, mock_get_credentials, localhost_client
+    mock_load, mock_is_authenticated, mock_auth_aws_iam, mock_get_credentials, vault_creds, localhost_client
 ):
     """
     Test that the aws_iam method *with only* hardcoded aws creds pulls creds
@@ -106,16 +104,19 @@ def test_auto_auth_aws_iam_method_role_only(
     local_vault_creds = {"vault_creds": {"auth_method": "aws_iam", "role": "test_role"}}
     mock_load.return_value = local_vault_creds
 
-    local_aws_creds = Mock(access_key="test_access_key", secret_key="test_secret_key", token="test_session_token")
-    mock_get_credentials.return_value = local_aws_creds
+    # we're mocking botocore.credentials.Credentials which uses `token` not `session_token`
+    local_boto_creds = Mock(
+        access_key=vault_creds["access_key"],
+        secret_key=vault_creds["secret_key"],
+        token=vault_creds.get("session_token", None),
+    )
+    mock_get_credentials.return_value = local_boto_creds
 
     mock_is_authenticated.return_value = False
 
     localhost_client.auto_auth("config.json", ac_parser="test_parser")
     mock_load.assert_called_with("config.json", ac_parser="test_parser")
-    mock_auth_kubernetes.assert_called_with(
-        access_key="test_access_key", secret_key="test_secret_key", session_token="test_session_token", role="test_role"
-    )
+    mock_auth_aws_iam.assert_called_with(**vault_creds, role="test_role")
 
 
 @patch("vault_anyconfig.vault_anyconfig.Client.auth_kubernetes")

--- a/tests/unit/test_vault_auth.py
+++ b/tests/unit/test_vault_auth.py
@@ -106,9 +106,7 @@ def test_auto_auth_aws_iam_method_role_only(
     local_vault_creds = {"vault_creds": {"auth_method": "aws_iam", "role": "test_role"}}
     mock_load.return_value = local_vault_creds
 
-    local_aws_creds = Mock(
-        access_key="test_access_key", secret_key="test_secret_key", session_token="test_session_token"
-    )
+    local_aws_creds = Mock(access_key="test_access_key", secret_key="test_secret_key", token="test_session_token")
     mock_get_credentials.return_value = local_aws_creds
 
     mock_is_authenticated.return_value = False

--- a/vault_anyconfig/vault_anyconfig.py
+++ b/vault_anyconfig/vault_anyconfig.py
@@ -75,6 +75,7 @@ class VaultAnyConfig(Client):
             - kubernetes: Kubernetes authentication can optionally provide a token_path field in the credentials file rather than directly providing
                 the JWT. Typically this path should be `/var/run/secrets/kubernetes.io/serviceaccount` See
                 https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#service-account-admission-controller
+            - aws_iam: When we are not provided hardcoded credentials let's pull them from the AWS SDK default locations
 
         Args:
             - vault_creds_file: string or file path with the credentials for the Vault
@@ -95,6 +96,16 @@ class VaultAnyConfig(Client):
             if token_path:
                 with open(token_path, "r") as token_file:
                     creds["jwt"] = token_file.read()
+
+        if auth_method == "auth_aws_iam" and ("access_key" not in creds and "secret_key" not in creds):
+            import boto3
+
+            session = boto3.Session()
+            credentials = session.get_credentials()
+            creds["access_key"] = credentials.access_key
+            creds["secret_key"] = credentials.secret_key
+            if "session_token" in creds:
+                creds["session_token"] = credentials.token
 
         try:
             method = getattr(self, auth_method)

--- a/vault_anyconfig/vault_anyconfig.py
+++ b/vault_anyconfig/vault_anyconfig.py
@@ -6,6 +6,7 @@ from os import chmod
 from os.path import abspath, isfile
 from stat import S_IRUSR, S_IWUSR
 
+import boto3
 from hvac import Client
 from anyconfig import dump as dump_base, dumps as dumps_base, load as load_base, loads as loads_base, merge
 
@@ -98,8 +99,6 @@ class VaultAnyConfig(Client):
                     creds["jwt"] = token_file.read()
 
         if auth_method == "auth_aws_iam" and ("access_key" not in creds and "secret_key" not in creds):
-            import boto3
-
             session = boto3.Session()
             credentials = session.get_credentials()
             creds["access_key"] = credentials.access_key
@@ -110,7 +109,9 @@ class VaultAnyConfig(Client):
         try:
             method = getattr(self, auth_method)
         except AttributeError:
-            raise NotImplementedError("HVAC does not provide {} as an authentication method".format(auth_method))
+            raise NotImplementedError(  # pylint: disable=raise-missing-from
+                "HVAC does not provide {} as an authentication method".format(auth_method)
+            )
 
         method(**creds)
         return self.is_authenticated()

--- a/vault_anyconfig/vault_anyconfig.py
+++ b/vault_anyconfig/vault_anyconfig.py
@@ -104,7 +104,7 @@ class VaultAnyConfig(Client):
             credentials = session.get_credentials()
             creds["access_key"] = credentials.access_key
             creds["secret_key"] = credentials.secret_key
-            if "session_token" in creds:
+            if credentials.token:
                 creds["session_token"] = credentials.token
 
         try:


### PR DESCRIPTION
When using `auth_aws_iam` and we are not provided hardcoded credentials let's pull them from the AWS SDK default locations!   Such as
* on-disk profiles in `~/.aws/config`
* `AWS_*` environment variables
* [EC2 Instance Metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
* [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)